### PR TITLE
fix: use complete npm release CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
           package-manager-cache: false
 
       - name: Install trusted-publishing npm CLI
-        run: npm install --global npm@12.0.0
+        run: |
+          npm install --global npm@12.0.1
+          npm --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Root cause

The stable publish workflow stopped before contacting npm because the pinned `npm@12.0.0` installation could not load its bundled `sigstore` dependency during `npm publish --dry-run`.

## Fix

- pin the release runner to `npm@12.0.1`
- print the effective npm version in the workflow log

## Verification

- npm 12.0.1 provenance module loads successfully
- workflow YAML parses
- open-source repository invariant tests pass
- no package was published by the failed run

After merge, the same manually approved stable publish workflow will be retried.