### PR TITLE
fix: support npm 12 pack output

### DIFF
--- a/scripts/release/smoke-packed.test.ts
+++ b/scripts/release/smoke-packed.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { packedFilename } from "./smoke-packed.ts";
+
+describe("npm pack output", () => {
+	test("accepts the npm 10 and 11 array format", () => {
+		expect(packedFilename('[{"filename":"sdk.tgz"}]', "sdk")).toBe("sdk.tgz");
+	});
+
+	test("accepts the npm 12 package-map format", () => {
+		expect(packedFilename('{"@openagentpack/sdk":{"filename":"sdk.tgz"}}', "sdk")).toBe("sdk.tgz");
+	});
+
+	test("rejects ambiguous output", () => {
+		expect(() => packedFilename("[]", "sdk")).toThrow("Unexpected npm pack output for sdk");
+	});
+});

--- a/scripts/release/smoke-packed.ts
+++ b/scripts/release/smoke-packed.ts
@@ -20,6 +20,13 @@ const root = resolve(import.meta.dirname, "../..");
 
 type PackedPackage = { filename: string };
 
+export function packedFilename(raw: string, pkg: string): string {
+	const parsed = JSON.parse(raw) as PackedPackage[] | Record<string, PackedPackage>;
+	const packed = Array.isArray(parsed) ? parsed : Object.values(parsed);
+	if (packed.length !== 1 || !packed[0]?.filename) throw new Error(`Unexpected npm pack output for ${pkg}`);
+	return packed[0].filename;
+}
+
 function run(command: string[], cwd: string, stdout: "inherit" | "pipe" = "inherit"): string {
 	const result = Bun.spawnSync(command, { cwd, stdout, stderr: "inherit" });
 	if (result.exitCode !== 0) throw new Error(`Command failed (${result.exitCode}): ${command.join(" ")}`);
@@ -38,9 +45,7 @@ function packPackages(destination: string): string[] {
 			licenseStaged = true;
 			originalManifest = rewriteManifestForPublish(pkgDir, versions);
 			const raw = run(["npm", "pack", "--json", "--pack-destination", destination], pkgDir, "pipe");
-			const packed = JSON.parse(raw) as PackedPackage[];
-			if (packed.length !== 1 || !packed[0]?.filename) throw new Error(`Unexpected npm pack output for ${pkg}`);
-			return join(destination, packed[0].filename);
+			return join(destination, packedFilename(raw, pkg));
 		} finally {
 			if (originalManifest !== undefined) restorePackageJson(pkgDir, originalManifest);
 			if (licenseStaged) restoreLicense(pkgDir, originalLicense);


### PR DESCRIPTION
## Root cause

npm 12 changed `npm pack --json` from a one-element array to a package-name keyed object. The release smoke test rejected the new valid format after all three publish dry-runs passed.

## Fix

- accept both npm 10/11 array output and npm 12 package-map output
- add regression coverage for both formats and ambiguous output

## Verification

- full pre-push verification passed
- package smoke test passed using npm 12.0.1
- no package was published by the failed workflow

After merge, retry the same approval-gated stable 0.0.2 publish.