### PR TITLE
fix: configure release tagger identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
               exit 1
             }
           else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git tag --annotate "${tag}" --message "${tag}"
             git push origin "${tag}"
           fi

--- a/scripts/open-source.test.ts
+++ b/scripts/open-source.test.ts
@@ -138,6 +138,8 @@ describe("open-source repository invariants", () => {
 		expect(workflow).toContain("id-token: write");
 		expect(workflow).toContain("cancel-in-progress: false");
 		expect(workflow).toContain("workflow_dispatch:");
+		expect(workflow).toContain('git config user.name "github-actions[bot]"');
+		expect(workflow).toContain("github-actions[bot]@users.noreply.github.com");
 	});
 
 	test("public worktree has no high-confidence secrets or internal machine references", () => {


### PR DESCRIPTION
## Fix

Configure the repository-local Git identity before creating annotated release tags. This uses the official GitHub Actions bot noreply identity and prevents the post-publish tag step from failing on a fresh runner.

## Verification

- full pre-push verification passed
- release policy invariant covers the bot identity
- no private or internal email is used

The v0.0.2 tag and GitHub Release were recovered manually; this change protects future releases.