### PR TITLE
fix: create beta release branches with valid git syntax

### DIFF
--- a/.github/workflows/prepare-beta.yml
+++ b/.github/workflows/prepare-beta.yml
@@ -46,10 +46,10 @@ jobs:
           git fetch origin main
           if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
             git fetch origin "${branch}"
-            git checkout --branch "${branch}" --track "origin/${branch}"
+            git checkout -b "${branch}" --track "origin/${branch}"
             git merge --no-edit origin/main
           else
-            git checkout --branch "${branch}" origin/main
+            git checkout -b "${branch}" origin/main
             bunx changeset pre enter beta
           fi
 


### PR DESCRIPTION
## Summary

- replace invalid `git checkout --branch` invocations with `git checkout -b`
- unblock the Prepare Beta Release workflow on GitHub-hosted runners

## Behavior / risk

The existing workflow always fails before creating a beta branch because `git checkout` does not support `--branch`. This changes only branch creation syntax; branch names, tracking configuration, version calculation, and publishing gates remain unchanged.

## Validation

- reproduced the failure in Prepare Beta Release runs 29733176912 and 29733250640
- `git diff --check`
- push verification profile: typecheck, architecture checks, tests, and changed-file lint