### PR TITLE
fix: install dependencies before beta versioning

### DIFF
--- a/.github/workflows/prepare-beta.yml
+++ b/.github/workflows/prepare-beta.yml
@@ -50,11 +50,19 @@ jobs:
             git merge --no-edit origin/main
           else
             git checkout -b "${branch}" origin/main
-            bunx changeset pre enter beta
           fi
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Enter prerelease mode for a new beta series
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          branch="release/${VERSION}-beta"
+          if ! git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            bun run changeset -- pre enter beta
+          fi
 
       - name: Calculate next beta version
         run: bun run release:version


### PR DESCRIPTION
## Summary

- install the locked workspace dependencies before invoking the Changesets CLI
- enter prerelease mode only when the beta release branch does not already exist

## Behavior / risk

The Prepare Beta Release workflow currently resolves an unrelated `changeset` package and fails before versioning because dependencies are not installed. This preserves the existing beta branch/version rules while ensuring the repository-pinned Changesets CLI is used.

## Validation

- reproduced the failure in Prepare Beta Release run 29735313780
- `bun run changeset -- --help`
- `git diff --check`
- push verification profile: typecheck, architecture checks, tests, and changed-file lint