### PR TITLE
feat: add DocumentSegment for inline HTML/SVG/Mermaid rendering

### DIFF
--- a/apps/webui/src/app/desktop.css
+++ b/apps/webui/src/app/desktop.css
@@ -5280,7 +5280,6 @@ dialog.case-modal-overlay {
 	width: 100%;
 	height: 240px;
 	border: 0;
-	pointer-events: none;
 }
 
 /* ── Lightbox (fullscreen media preview) ── */

--- a/apps/webui/src/app/desktop.css
+++ b/apps/webui/src/app/desktop.css
@@ -5229,6 +5229,60 @@ dialog.case-modal-overlay {
 	color: #b91c1c;
 }
 
+/* ── Inline Document Card (HTML / SVG / Mermaid preview) ── */
+
+.inline-document-card {
+	border-radius: 10px;
+	overflow: hidden;
+	border: 1px solid rgba(0, 0, 0, 0.08);
+	background: #fff;
+	max-width: 420px;
+}
+
+.inline-document-bar {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 12px;
+	font-size: 13px;
+	color: #374151;
+	background: #f9fafb;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.inline-document-title {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.inline-document-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 12px;
+	color: #6b7280;
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 2px 4px;
+	border-radius: 4px;
+}
+
+.inline-document-btn:hover {
+	color: #2563eb;
+	background: rgba(37, 99, 235, 0.06);
+}
+
+.inline-document-frame {
+	display: block;
+	width: 100%;
+	height: 240px;
+	border: 0;
+	pointer-events: none;
+}
+
 /* ── Lightbox (fullscreen media preview) ── */
 
 .lightbox-overlay {

--- a/apps/webui/src/components/ArtifactView.tsx
+++ b/apps/webui/src/components/ArtifactView.tsx
@@ -9,7 +9,10 @@ import {
 	type Artifact,
 	type ArtifactSegment,
 	type DeliveredFile,
+	type DocumentSegment,
+	documentTypeLabel,
 	preferInlineMarkdownPreview,
+	resolveDocumentContent,
 } from "@/lib/view/artifact";
 
 interface ArtifactViewProps {
@@ -183,6 +186,34 @@ function WebFrame({ artifact }: { artifact: Artifact }) {
 	);
 }
 
+function DocumentFrame({ segment }: { segment: DocumentSegment }) {
+	const title = segment.title ?? documentTypeLabel(segment.mimeType);
+	const srcDoc = resolveDocumentContent(segment);
+	const openNew = (event: MouseEvent) => {
+		event.preventDefault();
+		void openHtmlArtifactInNewWindow("", srcDoc);
+	};
+	return (
+		<div className="artifact-frame-wrap">
+			<div className="artifact-frame-bar">
+				<span className="artifact-frame-url" title={title}>
+					{title}
+				</span>
+				<button type="button" className="artifact-frame-btn" onClick={openNew}>
+					<ExternalLink size={14} />
+					新窗口打开
+				</button>
+			</div>
+			<iframe
+				className="artifact-frame"
+				srcDoc={srcDoc}
+				title={title}
+				sandbox="allow-scripts allow-popups allow-forms allow-same-origin"
+			/>
+		</div>
+	);
+}
+
 function FileCard({ artifact }: { artifact: Artifact }) {
 	const access = useArtifactAccess();
 	const fileName = artifactDisplayName(artifact.url, artifact.title);
@@ -291,6 +322,8 @@ function segmentKey(segment: ArtifactSegment): string {
 			return `artifact:${segment.artifact.url}`;
 		case "delivered_file":
 			return `delivered:${segment.file.file_id}`;
+		case "document":
+			return `document:${segment.mimeType}:${segment.content.slice(0, 128)}`;
 	}
 }
 
@@ -323,6 +356,8 @@ function ArtifactBlock({ segment }: { segment: ArtifactSegment }) {
 			}
 		case "delivered_file":
 			return <DeliveredFileCard file={segment.file} />;
+		case "document":
+			return <DocumentFrame segment={segment} />;
 	}
 }
 

--- a/apps/webui/src/components/task-run-modal/InlineArtifactCard.tsx
+++ b/apps/webui/src/components/task-run-modal/InlineArtifactCard.tsx
@@ -1,9 +1,11 @@
-import { Download, ExternalLink, FileText, Loader2, Play } from "lucide-react";
+import { Code, Download, ExternalLink, FileText, Loader2, Play } from "lucide-react";
 import { type MouseEvent, useState } from "react";
 import { useArtifactAccess } from "@/lib/artifact-access-context";
 import { artifactDisplayName } from "@/lib/artifact-file-name";
 import { getFileDownloadUrl } from "@/lib/domain/file-api";
-import type { Artifact, ArtifactSegment, DeliveredFile } from "@/lib/view/artifact";
+import { openHtmlArtifactInNewWindow } from "@/lib/hooks/useHtmlArtifactPreview";
+import type { Artifact, ArtifactSegment, DeliveredFile, DocumentSegment } from "@/lib/view/artifact";
+import { documentTypeLabel, resolveDocumentContent } from "@/lib/view/artifact";
 import { Lightbox } from "../Lightbox";
 
 function formatBytes(bytes?: number): string {
@@ -154,6 +156,29 @@ function InlineDeliveredFileCard({ file }: { file: DeliveredFile }) {
 	);
 }
 
+function InlineDocumentCard({ segment }: { segment: DocumentSegment }) {
+	const title = segment.title ?? documentTypeLabel(segment.mimeType);
+	const srcDoc = resolveDocumentContent(segment);
+	const openNew = (e: MouseEvent) => {
+		e.preventDefault();
+		void openHtmlArtifactInNewWindow("", srcDoc);
+	};
+
+	return (
+		<div className="inline-document-card">
+			<div className="inline-document-bar">
+				<Code size={14} />
+				<span className="inline-document-title">{title}</span>
+				<button type="button" className="inline-document-btn" onClick={openNew}>
+					<ExternalLink size={13} />
+					新窗口
+				</button>
+			</div>
+			<iframe className="inline-document-frame" srcDoc={srcDoc} title={title} sandbox="allow-scripts" />
+		</div>
+	);
+}
+
 // ---------------------------------------------------------------------------
 // 主组件
 // ---------------------------------------------------------------------------
@@ -213,6 +238,10 @@ export function InlineArtifactCard({ segments }: InlineArtifactCardProps) {
 						}
 					case "delivered_file":
 						return <InlineDeliveredFileCard key={segment.file.file_id} file={segment.file} />;
+					case "document":
+						return (
+							<InlineDocumentCard key={`doc:${segment.mimeType}:${segment.content.slice(0, 64)}`} segment={segment} />
+						);
 					case "text":
 						// 纯文本已在 assistant 消息气泡中渲染，不再重复
 						return null;

--- a/apps/webui/src/lib/view/artifact.test.ts
+++ b/apps/webui/src/lib/view/artifact.test.ts
@@ -3,9 +3,11 @@ import type { SessionEvent } from "@openagentpack/sdk";
 import {
 	classifyUrl,
 	collectDeliveredFiles,
+	documentTypeLabel,
 	extractArtifacts,
 	lastAssistantText,
 	preferInlineMarkdownPreview,
+	resolveDocumentContent,
 } from "./artifact";
 
 function deliveredEvent(artifact: Record<string, unknown>): SessionEvent {
@@ -309,5 +311,158 @@ describe("collectDeliveredFiles", () => {
 				deliveredEvent({ filename: "no-id.html" }),
 			]),
 		).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Document segment extraction
+// ---------------------------------------------------------------------------
+
+/** Generate a realistic HTML document string of a given approximate length. */
+function makeHtmlDocument(minChars = 1200): string {
+	const body = `<h1>Report Title</h1>\n<p>${"This is a paragraph of report content with data-driven insights. ".repeat(
+		Math.ceil(minChars / 60),
+	)}</p>`;
+	return `<!DOCTYPE html>\n<html lang="en">\n<head><meta charset="UTF-8"><title>Report</title></head>\n<body>\n${body}\n</body>\n</html>`;
+}
+
+/** Generate a Mermaid diagram of a given approximate length. */
+function makeMermaidDiagram(minChars = 600): string {
+	const nodes = Array.from({ length: Math.ceil(minChars / 50) }, (_, i) => `  N${i}["Node ${i} description text"]`);
+	const edges = Array.from({ length: nodes.length - 1 }, (_, i) => `  N${i} --> N${i + 1}`);
+	return `graph TD\n${nodes.join("\n")}\n${edges.join("\n")}`;
+}
+
+describe("document extraction", () => {
+	test("inline HTML document is extracted as a document segment", () => {
+		const html = makeHtmlDocument();
+		const input = `以下是报告：\n\n${html}`;
+		const { segments } = extractArtifacts(input);
+		const docs = segments.filter((s) => s.type === "document");
+		expect(docs).toHaveLength(1);
+		expect(docs[0]).toMatchObject({ type: "document", mimeType: "text/html" });
+		// The preamble text should survive as a text segment.
+		const texts = segments.filter((s) => s.type === "text");
+		expect(texts.some((s) => s.type === "text" && s.content.includes("以下是报告"))).toBe(true);
+	});
+
+	test("inline HTML document title is extracted from <title>", () => {
+		const html = makeHtmlDocument();
+		const input = html;
+		const { segments } = extractArtifacts(input);
+		const doc = segments.find((s) => s.type === "document");
+		expect(doc?.type === "document" ? doc.title : undefined).toBe("Report");
+	});
+
+	test("URLs inside an extracted HTML document are NOT extracted as artifacts", () => {
+		const html = makeHtmlDocument().replace(
+			"</head>",
+			'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet"></head>',
+		);
+		const { segments } = extractArtifacts(html);
+		const artifacts = segments.filter((s) => s.type === "artifact" || s.type === "images");
+		expect(artifacts).toHaveLength(0);
+	});
+
+	test("short fenced HTML block stays as text (below threshold)", () => {
+		const input = [
+			"### 交付文件：`index.html`",
+			"",
+			"```html",
+			"<!DOCTYPE html>",
+			'<link rel="preconnect" href="https://fonts.googleapis.com">',
+			'<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
+			'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet">',
+			"```",
+			"",
+			"预览：https://preview.example.com/page",
+		].join("\n");
+		const { segments } = extractArtifacts(input);
+		// The fenced block is too short to be a document — stays as text.
+		expect(segments.some((s) => s.type === "text" && s.content.includes("fonts.googleapis.com"))).toBe(true);
+		expect(segments.every((s) => s.type !== "document")).toBe(true);
+	});
+
+	test("large fenced HTML block is extracted as a document segment", () => {
+		const htmlContent = makeHtmlDocument(1000);
+		const input = `Report:\n\n\`\`\`html\n${htmlContent}\n\`\`\`\n\nDone.`;
+		const { segments } = extractArtifacts(input);
+		const docs = segments.filter((s) => s.type === "document");
+		expect(docs).toHaveLength(1);
+		expect(docs[0]).toMatchObject({ type: "document", mimeType: "text/html" });
+		// The preamble and postamble should survive as text segments.
+		expect(segments.some((s) => s.type === "text" && s.content.includes("Report:"))).toBe(true);
+		expect(segments.some((s) => s.type === "text" && s.content.includes("Done."))).toBe(true);
+	});
+
+	test("fenced mermaid block is extracted as a document segment", () => {
+		const mermaid = makeMermaidDiagram(600);
+		const input = `Diagram:\n\n\`\`\`mermaid\n${mermaid}\n\`\`\`\n\nEnd.`;
+		const { segments } = extractArtifacts(input);
+		const docs = segments.filter((s) => s.type === "document");
+		expect(docs).toHaveLength(1);
+		expect(docs[0]).toMatchObject({ type: "document", mimeType: "text/mermaid" });
+	});
+
+	test("truncated inline HTML (no </html>) is still extracted as document", () => {
+		// Simulate a truncated HTML stream: starts with DOCTYPE but never closes.
+		const truncatedHtml = `<!DOCTYPE html>\n<html>\n<head><title>Partial</title></head>\n<body>\n${"<p>content</p>\n".repeat(80)}`;
+		const { segments } = extractArtifacts(truncatedHtml);
+		const docs = segments.filter((s) => s.type === "document");
+		expect(docs).toHaveLength(1);
+		expect(docs[0]).toMatchObject({ type: "document", mimeType: "text/html" });
+	});
+
+	test("truncated HTML with short preamble is extracted as document", () => {
+		// The common agent pattern: "以下是报告：\n\n<!DOCTYPE html>...(truncated)..."
+		const preamble = "以下是基于你提供的素材整理而成的 HTML 格式行业研究报告。\n\n";
+		const truncatedHtml = `<!DOCTYPE html>\n<html lang="zh-CN">\n<head><title>Report</title></head>\n<body>\n${"<p>报告内容段落。</p>\n".repeat(100)}`;
+		const input = preamble + truncatedHtml;
+		expect(input).not.toMatch(/<\/html>/i); // no closing tag = truncated
+		const { segments } = extractArtifacts(input);
+		const docs = segments.filter((s) => s.type === "document");
+		expect(docs).toHaveLength(1);
+		expect(docs[0]).toMatchObject({ type: "document", mimeType: "text/html" });
+		// Preamble survives as text.
+		const texts = segments.filter((s) => s.type === "text");
+		expect(texts.some((s) => s.type === "text" && s.content.includes("以下是基于"))).toBe(true);
+	});
+
+	test("preferInlineMarkdownPreview returns false when document segments exist", () => {
+		const html = makeHtmlDocument();
+		const input = `![img](https://x.com/1.png)\n\nLong text content here for testing.\n\n${html}`;
+		const { segments } = extractArtifacts(input);
+		expect(preferInlineMarkdownPreview(segments)).toBe(false);
+	});
+});
+
+describe("resolveDocumentContent", () => {
+	test("returns HTML content as-is", () => {
+		const html = "<!DOCTYPE html><html><body>Hello</body></html>";
+		const result = resolveDocumentContent({ type: "document", content: html, mimeType: "text/html" });
+		expect(result).toBe(html);
+	});
+
+	test("returns SVG content as-is", () => {
+		const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>';
+		const result = resolveDocumentContent({ type: "document", content: svg, mimeType: "image/svg+xml" });
+		expect(result).toBe(svg);
+	});
+
+	test("wraps Mermaid content in an HTML shell with mermaid.js", () => {
+		const mermaid = "graph TD\n  A --> B";
+		const result = resolveDocumentContent({ type: "document", content: mermaid, mimeType: "text/mermaid" });
+		expect(result).toContain("mermaid.min.js");
+		expect(result).toContain('<pre class="mermaid">');
+		expect(result).toContain("graph TD");
+		expect(result).toContain("mermaid.initialize");
+	});
+});
+
+describe("documentTypeLabel", () => {
+	test("returns correct labels", () => {
+		expect(documentTypeLabel("text/html")).toBe("HTML 文档");
+		expect(documentTypeLabel("image/svg+xml")).toBe("SVG 图形");
+		expect(documentTypeLabel("text/mermaid")).toBe("Mermaid 图表");
 	});
 });

--- a/apps/webui/src/lib/view/artifact.test.ts
+++ b/apps/webui/src/lib/view/artifact.test.ts
@@ -233,9 +233,9 @@ describe("extractArtifacts", () => {
 			"",
 			"```html",
 			"<!DOCTYPE html>",
-			'<link rel="preconnect" href="https://fonts.googleapis.com">',
-			'<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
-			'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet">',
+			'<link rel="preconnect" href="https://cdn.example.test">',
+			'<link rel="preconnect" href="https://assets.example.test" crossorigin>',
+			'<link href="https://cdn.example.test/styles.css" rel="stylesheet">',
 			"```",
 			"",
 			"预览：https://preview.example.com/page",
@@ -357,7 +357,7 @@ describe("document extraction", () => {
 	test("URLs inside an extracted HTML document are NOT extracted as artifacts", () => {
 		const html = makeHtmlDocument().replace(
 			"</head>",
-			'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet"></head>',
+			'<link href="https://cdn.example.test/styles.css" rel="stylesheet"></head>',
 		);
 		const { segments } = extractArtifacts(html);
 		const artifacts = segments.filter((s) => s.type === "artifact" || s.type === "images");
@@ -370,16 +370,16 @@ describe("document extraction", () => {
 			"",
 			"```html",
 			"<!DOCTYPE html>",
-			'<link rel="preconnect" href="https://fonts.googleapis.com">',
-			'<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
-			'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet">',
+			'<link rel="preconnect" href="https://cdn.example.test">',
+			'<link rel="preconnect" href="https://assets.example.test" crossorigin>',
+			'<link href="https://cdn.example.test/styles.css" rel="stylesheet">',
 			"```",
 			"",
 			"预览：https://preview.example.com/page",
 		].join("\n");
 		const { segments } = extractArtifacts(input);
 		// The fenced block is too short to be a document — stays as text.
-		expect(segments.some((s) => s.type === "text" && s.content.includes("fonts.googleapis.com"))).toBe(true);
+		expect(segments.some((s) => s.type === "text" && s.content.includes("cdn.example.test"))).toBe(true);
 		expect(segments.every((s) => s.type !== "document")).toBe(true);
 	});
 

--- a/apps/webui/src/lib/view/artifact.ts
+++ b/apps/webui/src/lib/view/artifact.ts
@@ -22,7 +22,26 @@ export type ArtifactSegment =
 	| { type: "text"; content: string }
 	| { type: "images"; artifacts: Artifact[] }
 	| { type: "artifact"; artifact: Artifact }
-	| { type: "delivered_file"; file: DeliveredFile };
+	| { type: "delivered_file"; file: DeliveredFile }
+	| DocumentSegment;
+
+/** MIME type for self-contained rich documents extracted from agent messages. */
+export type DocumentMimeType = "text/html" | "image/svg+xml" | "text/mermaid";
+
+/**
+ * A self-contained rich document (HTML page, SVG graphic, Mermaid diagram) that the agent
+ * produced inline in a chat message. Rendered via sandboxed iframe (`srcdoc`) instead of
+ * being sanitized through the Markdown pipeline.
+ */
+export interface DocumentSegment {
+	type: "document";
+	/** Raw document source code (HTML / SVG / Mermaid syntax). */
+	content: string;
+	/** Document MIME, determines how the iframe renders the content. */
+	mimeType: DocumentMimeType;
+	/** Optional human-readable title (inferred from fence lang tag or `<title>` element). */
+	title?: string;
+}
 
 export interface ArtifactResult {
 	segments: ArtifactSegment[];
@@ -152,7 +171,7 @@ type ContentRegion = { kind: "prose"; text: string } | { kind: "code"; text: str
 
 const RE_INLINE_CODE = /`[^`\n]+`/g;
 
-type FenceSpan = { start: number; end: number; text: string };
+type FenceSpan = { start: number; end: number; text: string; lang: string };
 
 /**
  * Locate fenced ``` blocks. Handles:
@@ -176,6 +195,7 @@ function findFencedCodeBlocks(text: string): FenceSpan[] {
 		}
 
 		const tickCount = open[1].length;
+		const lang = (open[2] ?? "").trim().split(/\s+/)[0] ?? "";
 		const start = offset;
 		offset += line.length + 1;
 		i += 1;
@@ -188,7 +208,7 @@ function findFencedCodeBlocks(text: string): FenceSpan[] {
 			const closeOnly = closeLine.match(/^(`{3,})\s*$/);
 			if (closeOnly && closeOnly[1].length >= tickCount) {
 				const end = offset + closeLine.length;
-				blocks.push({ start, end, text: text.slice(start, end) });
+				blocks.push({ start, end, text: text.slice(start, end), lang });
 				offset = end + 1;
 				i += 1;
 				closed = true;
@@ -199,7 +219,7 @@ function findFencedCodeBlocks(text: string): FenceSpan[] {
 			const inlineClose = closeLine.match(/(`{3,})\s*$/);
 			if (inlineClose && (inlineClose.index ?? 0) > 0 && inlineClose[1].length >= tickCount) {
 				const end = lineStart + (inlineClose.index ?? 0) + inlineClose[1].length;
-				blocks.push({ start, end, text: text.slice(start, end) });
+				blocks.push({ start, end, text: text.slice(start, end), lang });
 				offset = end + 1;
 				i += 1;
 				closed = true;
@@ -211,7 +231,7 @@ function findFencedCodeBlocks(text: string): FenceSpan[] {
 		}
 
 		if (!closed) {
-			blocks.push({ start, end: text.length, text: text.slice(start) });
+			blocks.push({ start, end: text.length, text: text.slice(start), lang });
 			break;
 		}
 	}
@@ -293,7 +313,212 @@ function extractArtifactsFromProse(
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Document detection — self-contained rich documents (HTML / SVG / Mermaid)
+// ---------------------------------------------------------------------------
+
+/** Fenced code block languages that represent a renderable document rather than source code. */
+const DOCUMENT_LANGUAGES = new Set(["html", "htm", "svg", "mermaid"]);
+
+const LANG_TO_MIME: Record<string, DocumentMimeType> = {
+	html: "text/html",
+	htm: "text/html",
+	svg: "image/svg+xml",
+	mermaid: "text/mermaid",
+};
+
+/** Minimum character count for a fenced document block (avoids extracting short code snippets). */
+const MIN_FENCED_DOCUMENT_CHARS = 500;
+
+/**
+ * Matches a complete inline HTML document: `<!DOCTYPE html>…</html>` or `<html…>…</html>`.
+ * Uses a non-greedy match on the closing tag to handle multiple HTML blocks in theory,
+ * though in practice a single document per message is the common case.
+ */
+const RE_INLINE_HTML_DOC = /<!DOCTYPE\s+html[^>]*>[\s\S]*?<\/html\s*>/i;
+
+/** Minimum character count for an inline HTML document. */
+const MIN_INLINE_HTML_CHARS = 1000;
+
+interface DocumentSpan {
+	start: number;
+	end: number;
+	segment: DocumentSegment;
+}
+
+/** Extract the `<title>…</title>` text from an HTML string, if present. */
+function extractHtmlTitle(html: string): string | undefined {
+	const match = /<title[^>]*>([^<]+)<\/title>/i.exec(html);
+	return match?.[1]?.trim() || undefined;
+}
+
+/**
+ * Scan the full message text for self-contained document blocks:
+ *   1. Fenced code blocks whose language tag is a document language (html/svg/mermaid)
+ *      and whose inner content meets the minimum size threshold.
+ *   2. Inline HTML documents (`<!DOCTYPE html>…</html>`) not already inside a fence.
+ *
+ * Returns spans sorted by start position. The caller removes them from the text before
+ * running URL extraction on the remaining prose.
+ */
+function extractDocumentSpans(text: string): DocumentSpan[] {
+	const spans: DocumentSpan[] = [];
+	const fences = findFencedCodeBlocks(text);
+
+	for (const fence of fences) {
+		if (!DOCUMENT_LANGUAGES.has(fence.lang.toLowerCase())) continue;
+
+		// Inner content = everything between the opening and closing fence lines.
+		const firstNewline = fence.text.indexOf("\n");
+		const innerText = firstNewline >= 0 ? fence.text.slice(firstNewline + 1) : "";
+		// Strip trailing closing fence line (```) if present.
+		const cleaned = innerText.replace(/```+\s*$/, "").trim();
+		if (cleaned.length < MIN_FENCED_DOCUMENT_CHARS) continue;
+
+		const mime = LANG_TO_MIME[fence.lang.toLowerCase()];
+		if (!mime) continue;
+
+		spans.push({
+			start: fence.start,
+			end: fence.end,
+			segment: { type: "document", content: cleaned, mimeType: mime },
+		});
+	}
+
+	// Inline HTML documents — only look in prose regions not covered by a fence.
+	const fencedRanges = fences.map((f) => ({ start: f.start, end: f.end }));
+	const isInsideFence = (start: number) => fencedRanges.some((r) => start >= r.start && start < r.end);
+
+	// Strategy: search the full text for RE_INLINE_HTML_DOC first (complete documents).
+	let searchFrom = 0;
+	while (searchFrom < text.length) {
+		const match = RE_INLINE_HTML_DOC.exec(text.slice(searchFrom));
+		if (!match) break;
+		const absStart = searchFrom + match.index;
+		if (!isInsideFence(absStart) && match[0].length >= MIN_INLINE_HTML_CHARS) {
+			spans.push({
+				start: absStart,
+				end: absStart + match[0].length,
+				segment: {
+					type: "document",
+					content: match[0],
+					mimeType: "text/html",
+					title: extractHtmlTitle(match[0]),
+				},
+			});
+			searchFrom = absStart + match[0].length;
+			continue;
+		}
+		searchFrom = absStart + 1;
+	}
+
+	// Truncated HTML document: DOCTYPE/<html present but no closing tag (stream was cut).
+	// Handles the common case where the agent writes a short preamble ("以下是报告：")
+	// before the HTML document, and the stream is truncated mid-document.
+	if (!spans.some((s) => s.segment.mimeType === "text/html")) {
+		const hasClosing = /<\/html\s*>/i.test(text);
+		if (!hasClosing) {
+			// Look for DOCTYPE or <html anywhere in the text (not just at position 0).
+			const docStartMatch = /<!DOCTYPE\s+html|<html[\s>]/i.exec(text);
+			if (docStartMatch) {
+				const docStart = docStartMatch.index;
+				// Only treat as a document if the preamble is short (< 300 chars) and
+				// the HTML content is substantial — avoids false positives on articles
+				// that merely mention HTML in passing.
+				const htmlContentLen = text.length - docStart;
+				if (docStart < 300 && htmlContentLen >= MIN_INLINE_HTML_CHARS && !isInsideFence(docStart)) {
+					spans.push({
+						start: docStart,
+						end: text.length,
+						segment: {
+							type: "document",
+							content: text.slice(docStart),
+							mimeType: "text/html",
+							title: extractHtmlTitle(text),
+						},
+					});
+				}
+			}
+		}
+	}
+
+	spans.sort((a, b) => a.start - b.start);
+	return spans;
+}
+
+/** Human-readable label for a document MIME type (used as fallback title in UI). */
+export function documentTypeLabel(mimeType: DocumentMimeType): string {
+	switch (mimeType) {
+		case "text/html":
+			return "HTML 文档";
+		case "image/svg+xml":
+			return "SVG 图形";
+		case "text/mermaid":
+			return "Mermaid 图表";
+	}
+}
+
+/**
+ * Resolve a document segment into a complete HTML string suitable for `<iframe srcDoc>`.
+ * HTML and SVG documents are returned as-is (SVG is self-rendering in browsers).
+ * Mermaid syntax is wrapped in a minimal HTML shell that loads mermaid.js from CDN.
+ */
+export function resolveDocumentContent(segment: DocumentSegment): string {
+	if (segment.mimeType === "text/mermaid") {
+		return [
+			"<!DOCTYPE html>",
+			'<html><head><meta charset="UTF-8">',
+			'<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>',
+			"<style>body{margin:16px;font-family:system-ui,sans-serif}</style>",
+			"</head><body>",
+			'<pre class="mermaid">',
+			segment.content,
+			"</pre>",
+			"<script>mermaid.initialize({startOnLoad:true})</script>",
+			"</body></html>",
+		].join("\n");
+	}
+	// HTML and SVG documents are self-contained.
+	return segment.content;
+}
+
 export function extractArtifacts(text: string): ArtifactResult {
+	if (!text) return { segments: [] };
+
+	// Pass 1: extract self-contained document blocks (HTML / SVG / Mermaid).
+	const docSpans = extractDocumentSpans(text);
+
+	if (docSpans.length > 0) {
+		// Build ordered list of text slices and document segments.
+		const allSegments: ArtifactSegment[] = [];
+		let cursor = 0;
+
+		for (const span of docSpans) {
+			if (cursor < span.start) {
+				const slice = text.slice(cursor, span.start);
+				allSegments.push(...extractNonDocumentArtifacts(slice).segments);
+			}
+			allSegments.push(span.segment);
+			cursor = span.end;
+		}
+
+		if (cursor < text.length) {
+			allSegments.push(...extractNonDocumentArtifacts(text.slice(cursor)).segments);
+		}
+
+		return { segments: allSegments };
+	}
+
+	// No documents found — use the standard URL extraction pipeline.
+	return extractNonDocumentArtifacts(text);
+}
+
+/**
+ * Standard artifact extraction for text that has already had document blocks removed.
+ * Extracts URLs (images, links, bare URLs) from prose regions and preserves fenced code
+ * blocks as plain text segments.
+ */
+function extractNonDocumentArtifacts(text: string): ArtifactResult {
 	if (!text) return { segments: [] };
 
 	const bag = {
@@ -332,7 +557,7 @@ export function extractArtifacts(text: string): ArtifactResult {
  */
 export function preferInlineMarkdownPreview(segments: ArtifactSegment[]): boolean {
 	if (!segments.some((s) => s.type === "images")) return false;
-	if (segments.some((s) => s.type === "artifact")) return false;
+	if (segments.some((s) => s.type === "artifact" || s.type === "document")) return false;
 
 	const textSegments = segments.filter((s) => s.type === "text");
 	if (textSegments.length === 0) return false;

--- a/packages/sdk/src/internal/core/session-event-sanitizer.ts
+++ b/packages/sdk/src/internal/core/session-event-sanitizer.ts
@@ -8,6 +8,21 @@ import type { ProviderSessionEvent } from "../types/session-event.ts";
 
 const DEFAULT_TEXT_LIMIT = 4000;
 const TOOL_TEXT_LIMIT = 8000;
+/** Self-contained rich documents (HTML/SVG/Mermaid) need much more room than chat text. */
+const DOCUMENT_TEXT_LIMIT = 32_000;
+
+/**
+ * Lightweight check: does this message text contain a self-contained rich document?
+ * Used by the sanitizer to pick a higher truncation limit so HTML reports, SVG
+ * graphics and Mermaid diagrams survive transport intact.
+ */
+function hasDocumentContent(text: string): boolean {
+	// Fenced document code block: ```html, ```svg, ```mermaid
+	if (/```(?:html|htm|svg|mermaid)\s*\n/i.test(text)) return true;
+	// Inline HTML document (DOCTYPE or <html tag)
+	if (/<(?:!DOCTYPE\s+)?html[\s>]/i.test(text)) return true;
+	return false;
+}
 
 export function sanitizeSessionEvents(
 	events: ProviderSessionEvent[],
@@ -27,8 +42,14 @@ export function sanitizeSessionEvent(
 	// has no dedicated fields for them, so they live in the open metadata bag where the
 	// presentation layer can read them uniformly).
 	const isToolEvent = event.type === "tool_result" || event.type === "tool_use";
-	const textLimit = isToolEvent ? TOOL_TEXT_LIMIT : DEFAULT_TEXT_LIMIT;
 	const primarySource = event.content ?? (event.type === "tool_use" ? event.tool_input : undefined);
+	// Pick a truncation limit appropriate to the content: tool events get 8 000 chars,
+	// message events containing self-contained documents get 32 000, everything else 4 000.
+	const textLimit = isToolEvent
+		? TOOL_TEXT_LIMIT
+		: typeof primarySource === "string" && hasDocumentContent(primarySource)
+			? DOCUMENT_TEXT_LIMIT
+			: DEFAULT_TEXT_LIMIT;
 	const primary = sanitizeOptionalText(primarySource, textLimit);
 	const raw = options.includeRaw ? sanitizeUnknown(event.raw, TOOL_TEXT_LIMIT * 2) : undefined;
 	const redacted = Boolean(primary?.redacted || raw?.redacted);
@@ -96,11 +117,27 @@ function sanitizeUnknown(value: unknown, limit: number): SanitizedValue<unknown>
 
 function sanitizeText(value: string, limit: number): SanitizedValue<string> {
 	const redacted = redactSensitiveText(value);
-	const truncated = redacted.length > limit;
+	if (redacted.length <= limit) {
+		return { value: redacted, redacted: redacted !== value, truncated: false };
+	}
+
+	// When the content is HTML, try to truncate at a tag boundary to avoid splitting
+	// an open tag (which would cause the browser to treat all subsequent text as a
+	// single malformed element).
+	let cut = limit;
+	if (/<[a-z][\s\S]*>/i.test(redacted)) {
+		const lastLt = redacted.lastIndexOf("<", cut);
+		const lastGt = redacted.lastIndexOf(">", cut);
+		if (lastLt > lastGt) {
+			// We're inside an unclosed tag — back up to before the `<`.
+			cut = lastLt;
+		}
+	}
+
 	return {
-		value: truncated ? `${redacted.slice(0, limit)}\n...[truncated ${redacted.length - limit} chars]` : redacted,
+		value: `${redacted.slice(0, cut)}\n...[truncated ${redacted.length - cut} chars]`,
 		redacted: redacted !== value,
-		truncated,
+		truncated: true,
 	};
 }
 


### PR DESCRIPTION
## Summary

Agent responses containing full documents (HTML reports, SVG diagrams, Mermaid charts) were previously unreadable due to a three-layer failure: server-side truncation at 4000 chars → artifact extraction blind spot for inline documents → rehype-sanitize stripping all HTML tags. The result was "内容已截断" with raw text only.

This PR adds a general `DocumentSegment` type to the artifact pipeline that handles any self-contained rich document output by agents.

### Changes

- **`artifact.ts`** — `extractDocumentSpans()` with two-pass detection: fenced code blocks with document languages (`html`/`svg`/`mermaid`, ≥500 chars) and inline HTML documents (≥1000 chars), including truncated streams missing `</html>`. Two-pass `extractArtifacts()`: documents first, then URL extraction on remaining text. Added `resolveDocumentContent()` (wraps Mermaid in HTML shell with CDN mermaid@11), `documentTypeLabel()`, `extractHtmlTitle()`.
- **`session-event-sanitizer.ts`** — New `DOCUMENT_TEXT_LIMIT = 32K` for document-containing events (vs 4K default / 8K tool). HTML-safe truncation at tag boundaries.
- **`InlineArtifactCard.tsx`** — New `InlineDocumentCard`: 240px sandboxed iframe preview in timeline with "新窗口" button.
- **`ArtifactView.tsx`** — New `DocumentFrame`: full-height iframe with toolbar for left-panel preview.
- **`desktop.css`** — Styles for `.inline-document-card`, `.inline-document-frame`, etc.
- **`artifact.test.ts`** — 13 new test cases covering extraction, resolution, and edge cases (44 total tests).

## Test plan

- [x] 44/44 unit tests pass (including 13 new document extraction tests)
- [x] TypeScript zero errors across webui + SDK
- [x] biome lint clean (pre-commit hook passes)
- [x] Browser verification: inline iframe preview renders with correct HTML content, "新窗口" opens full document in new window, scrolling works inside iframe
- [x] Pre-push verification harness passes (typecheck, architecture, tests)