### PR TITLE
test: cover Qoder environment variable parsing

### DIFF
--- a/packages/sdk/tests/fixtures/agent-environment-variables.yaml
+++ b/packages/sdk/tests/fixtures/agent-environment-variables.yaml
@@ -1,0 +1,16 @@
+version: "1"
+
+providers:
+  qoder:
+    api_key: test-token
+
+defaults:
+  provider: qoder
+
+agents:
+  assistant:
+    model: auto
+    instructions: Test environment variable parsing.
+    environment_variables:
+      FEATURE_FLAG: "on"
+      RETRY_COUNT: "3"

--- a/packages/sdk/tests/unit/parser.test.ts
+++ b/packages/sdk/tests/unit/parser.test.ts
@@ -79,3 +79,12 @@ test("rejects environment setup scripts over 64 KiB by UTF-8 byte length", () =>
 	expect(result.success).toBe(false);
 	if (!result.success) expect(result.error.issues[0]?.message).toContain("65536 UTF-8 bytes");
 });
+
+test("preserves Agent environment variables from YAML", async () => {
+	const { config, errors } = await loadConfig(resolve(FIXTURES, "agent-environment-variables.yaml"));
+	expect(errors).toEqual([]);
+	expect(config.agents?.assistant?.environment_variables).toEqual({
+		FEATURE_FLAG: "on",
+		RETRY_COUNT: "3",
+	});
+});


### PR DESCRIPTION
## What changed

- add a representative agents.yaml fixture with Qoder Agent environment variables
- verify the public YAML loader preserves the environment_variables map

## Why

The Qoder environment-variable support from PR #77 depends on this field surviving YAML schema parsing. A direct regression test prevents future schema changes from silently stripping the values before planning and apply.

## Impact

Test-only change. Runtime behavior is unchanged.

## Validation

- bun test packages/sdk/tests/unit/parser.test.ts
- bun run verify:scoped
- pre-push bun scripts/verify.ts push (full typecheck, architecture checks, tests, and lint)