### PR TITLE
fix(qoder): skip reserved environment metadata

### DIFF
--- a/packages/sdk/src/internal/providers/qoder/adapter.ts
+++ b/packages/sdk/src/internal/providers/qoder/adapter.ts
@@ -450,7 +450,9 @@ export class QoderAdapter implements ProviderAdapter {
 		const currentMetadata = (current.metadata ?? {}) as Record<string, unknown>;
 		const metadata = { ...((body.metadata ?? {}) as Record<string, string | null>) };
 		for (const key of Object.keys(currentMetadata)) {
-			if (!key.startsWith("agents.") && !(key in metadata)) metadata[key] = null;
+			// Qoder injects created_by into environment responses but rejects it on writes,
+			// including deletion tombstones such as { created_by: null }.
+			if (key !== "created_by" && !key.startsWith("agents.") && !(key in metadata)) metadata[key] = null;
 		}
 		body.metadata = metadata;
 		const res = (await client.post(`/environments/${id}`, body)) as Record<string, unknown>;

--- a/packages/sdk/tests/e2e/qoder-adapter-pagination.test.ts
+++ b/packages/sdk/tests/e2e/qoder-adapter-pagination.test.ts
@@ -166,7 +166,9 @@ describe("QoderAdapter environment contract", () => {
 		const { calls, restore } = mockFetch([
 			{
 				status: 200,
-				body: { metadata: { keep: "old", remove: "stale", "agents.project": "test-project" } },
+				body: {
+					metadata: { keep: "old", remove: "stale", created_by: "forward", "agents.project": "test-project" },
+				},
 			},
 			{ status: 200, body: { id: "env_1", type: "environment" } },
 		]);
@@ -190,6 +192,7 @@ describe("QoderAdapter environment contract", () => {
 				"agents.resource": "dev",
 			},
 		});
+		expect(calls[1]?.body).not.toHaveProperty("metadata.created_by");
 	});
 
 	test("exports normalized setup scripts and omits response-only package defaults", async () => {


### PR DESCRIPTION
## Summary

Prevent Qoder environment updates from sending the provider-managed `created_by` metadata field.

## Why

Qoder includes `created_by` in environment read responses but rejects that reserved key on writes, including `{ created_by: null }`. The update path previously tombstoned every undeclared non-`agents.*` metadata key, causing otherwise valid environment updates to fail with HTTP 400.

## Type

- [ ] New provider
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Tests

## Surface area

- [ ] Workspace/package boundaries
- [x] Provider interface / adapter contract
- [ ] YAML schema / config types
- [ ] CLI commands
- [ ] WebUI
- [ ] State management
- [ ] Execution / planning logic
- [x] Tests / fixtures
- [ ] None of the above

## Checklist

- [ ] `bun run verify:full` passes
- [x] New provider follows the six-file structure, if applicable
- [x] No new runtime dependencies added without justification

## Behavior / risk

Qoder environment updates now leave the provider-managed `created_by` field untouched while continuing to tombstone removed user metadata. This is narrowly scoped to the Qoder environment update request.

## Validation

- `bun test packages/sdk/tests/e2e/qoder-adapter-pagination.test.ts`
- `bun run verify:scoped`
- pre-push `bun scripts/verify.ts push`
- Live Qoder `agents apply`: environment, template, and channel updates completed successfully after the fix.
